### PR TITLE
Switched nested attribute character to '.'

### DIFF
--- a/lib/chef/knife/psearch.rb
+++ b/lib/chef/knife/psearch.rb
@@ -53,7 +53,7 @@ class Psearch < Chef::Knife
     specs = @keys.map { |i| i.split(",") }.flatten
     specs.each do |spc|
       name, value = spc.split("=")
-      key_hash[name] = value.split("_")
+      key_hash[name] = value.split(".")
     end
     # This seems like a sane default.  The results without the name
     # are usually not what we want.


### PR DESCRIPTION
Fixes 'platform_version', 'run_list' ect.
