### PR TITLE
Rely on chef_server_url as search_url has been removed.

### DIFF
--- a/lib/chef/search/partial_search.rb
+++ b/lib/chef/search/partial_search.rb
@@ -33,7 +33,7 @@ class Chef
     attr_accessor :rest
 
     def initialize(url=nil)
-      @rest = ::Chef::REST.new(url || ::Chef::Config[:search_url])
+      @rest = ::Chef::REST.new(url || ::Chef::Config[:chef_server_url])
     end
 
     # Search Solr for objects of a given type, for a given query. If you give


### PR DESCRIPTION
knife-psearch is currently broken on chef 11.6.0:

```
$ knife psearch node "fqdn:*" -VV --server-url https://chef-01
DEBUG: Signing the request as matthew
DEBUG: Sending HTTP Request via POST to :/search/node
DEBUG: ---- HTTP Status and Header Data: ----
DEBUG: HTTP 1.1 404 Not Found
DEBUG: content-type: text/html
DEBUG: connection: close
DEBUG: transfer-encoding: chunked
DEBUG: ---- End HTTP Status/Header Data ----
/usr/local/opt/rbenv/versions/1.9.3-p429/lib/ruby/1.9.1/net/http.rb:2633:in `error!': 404 "Not Found" (Net::HTTPServerException)
    from /usr/local/opt/rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/chef-11.6.0/lib/chef/rest.rb:207:in `block in raw_http_request'
    from /usr/local/opt/rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/chef-11.6.0/lib/chef/rest.rb:289:in `retriable_rest_request'
    from /usr/local/opt/rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/chef-11.6.0/lib/chef/rest.rb:167:in `raw_http_request'
<snip>
```

pull request fixes the server url.
